### PR TITLE
POI表示プロパティのバックアップ・復元機能の実装

### DIFF
--- a/SVGMapLv0.1_Class_r18module.js
+++ b/SVGMapLv0.1_Class_r18module.js
@@ -3358,6 +3358,22 @@ class SvgMap {
 	}
 
 	/**
+	 * アクティブなレイヤーに設定されているShowPoiProperyのバックアップを全て取得する
+	 * @returns {void} 戻り値なし
+	 */
+	backupShowPoiProperty() {
+		this.#mapTicker.showPoiProperty.backupShowPoiProperty();
+	}
+
+	/**
+	 * アクティブなレイヤーのShowPoiProperyをバックアップから復元する
+	 * @returns {void} 戻り値なし
+	 */
+	restoreShowPoiProperty() {
+		this.#mapTicker.showPoiProperty.restoreShowPoiProperty();
+	}
+
+	/**
 	 * ズームイン／アウト後のタイル読み込み開始タイマー
 	 * @param  {String} zoomInterval // msec
 	 * @returns

--- a/tests/unittest/ShowPoiProperty.test.js
+++ b/tests/unittest/ShowPoiProperty.test.js
@@ -5,7 +5,7 @@
 import { ShowPoiProperty } from "../../libs/ShowPoiProperty";
 import { mock_svgmapObj } from "./resources/mockParamerters";
 import { UtilFuncs } from "../../libs/UtilFuncs";
-import { jest } from "@jest/globals";
+import { expect, jest } from "@jest/globals";
 
 describe("unittest for ShowPoiProperty", () => {
 	describe("target ShowPoiProperty class", () => {
@@ -46,14 +46,157 @@ describe("unittest for ShowPoiProperty", () => {
 			showPoiProperty.showPoiPropertyWrapper(elm);
 			expect(elm.getAttribute("data-title")).toBe("Test Title");
 		});
+	});
 
-		it("setShowPoiProperty", () => {
-			// エラーがないことを確認
-			let mock_func = jest.fn();
-			// 関数を登録してみる
-			result = showPoiProperty.setShowPoiProperty(mock_func, "tasikasuuji");
-			// 関数削除
-			result = showPoiProperty.setShowPoiProperty(null, "tasikasuuji");
+	describe("backup/restore showPoiProperty functionality", () => {
+		let showPoiProperty;
+		let utilSpy, target;
+
+		beforeEach(() => {
+			showPoiProperty = new ShowPoiProperty(mock_svgmapObj, jest.fn(), "???");
+			target = document.createElement("div");
+
+			utilSpy = jest.spyOn(UtilFuncs, "getDocumentId").mockReturnValue("i5");
+		});
+
+		afterEach(() => {
+			// Mockのクリア
+			utilSpy.mockClear();
+			utilSpy.mockReset();
+			utilSpy.mockRestore();
+		});
+
+		it("should correctly backup and restore POI property settings", () => {
+			const initialFunc = jest.fn();
+			const customFunc = jest.fn();
+
+			// 初期設定
+			showPoiProperty.setShowPoiProperty(initialFunc, "i5");  // layer i5
+			showPoiProperty.setShowPoiProperty(customFunc); // global
+
+			// バックアップ前はhookがアクティブではない
+			expect(showPoiProperty.isHookActive()).toBe(false);
+
+			// バックアップ
+			showPoiProperty.backupShowPoiProperty();
+			// バックアップ後はhookがアクティブになる
+			expect(showPoiProperty.isHookActive()).toBe(true);
+
+			// POIクリックをシミュレート
+			showPoiProperty.showPoiPropertyWrapper(target);
+			expect(initialFunc).toHaveBeenCalledTimes(1); // initialFuncが呼び出されることを確認
+			expect(customFunc).toHaveBeenCalledTimes(0); // customFuncは呼び出されないことを確認
+
+			// 設定を変更
+			showPoiProperty.setShowPoiProperty(null, "i5"); //defaultに戻す
+			showPoiProperty.setShowPoiProperty(jest.fn());
+
+			// POIクリックをシミュレート
+			showPoiProperty.showPoiPropertyWrapper(target);
+			expect(initialFunc).toHaveBeenCalledTimes(1); // initialFuncが呼び出されないことを確認
+			expect(customFunc).toHaveBeenCalledTimes(0); // customFuncも呼び出されないことを確認
+
+			// 変更が適用されていることを確認 (直接アクセスできないため、setShowPoiPropertyの動作で間接的に確認)
+			// ここでは、isHookActiveがtrueのままであることを確認する
+			expect(showPoiProperty.isHookActive()).toBe(true);
+
+			// リストア
+			showPoiProperty.restoreShowPoiProperty();
+
+			// リストア後はhookがアクティブではない
+			expect(showPoiProperty.isHookActive()).toBe(false);
+
+			// 既にバックアップが存在する場合に上書きしないこと
+			showPoiProperty.backupShowPoiProperty(); // 最初のバックアップ
+			
+			showPoiProperty.setShowPoiProperty(jest.fn(), "i5"); // 新しい設定
+			showPoiProperty.backupShowPoiProperty(); // 再度バックアップを試みる
+			
+			// バックアップがない場合にrestoreShowPoiPropertyを呼び出してもエラーにならないこと
+			showPoiProperty.restoreShowPoiProperty(); // バックアップをクリア
+			showPoiProperty.restoreShowPoiProperty(); // バックアップがない状態で再度呼び出す
+			// エラーが発生しないことを確認 (JestのtoThrowを使用しない)
+			expect(() => showPoiProperty.restoreShowPoiProperty()).not.toThrow();
+		});
+
+		it("should not overwrite existing backup when backupShowPoiProperty is called again", () => {
+			const initialFunc = jest.fn();
+			const customFunc = jest.fn();
+			
+			showPoiProperty.setShowPoiProperty(initialFunc, "i5"); // layer i5
+			showPoiProperty.backupShowPoiProperty();
+			
+			// バックアップ後の状態を保存 (プライベートフィールドへの直接アクセスは避ける)
+			// ここでは、isHookActiveがtrueであることを確認する
+			expect(showPoiProperty.isHookActive()).toBe(true);
+
+			showPoiProperty.setShowPoiProperty(customFunc, "i5"); // layer i5
+
+			// showPoiPropertyWrapperを呼び出して、customFuncが呼び出されることを確認
+			// POIクリックをシミュレート
+			showPoiProperty.showPoiPropertyWrapper(target);
+			expect(initialFunc).toHaveBeenCalledTimes(0); // initialFuncは呼び出されないことを確認
+			expect(customFunc).toHaveBeenCalledTimes(1); // customFuncが呼び出されることを確認
+
+			// 再度バックアップを試みる
+			showPoiProperty.backupShowPoiProperty();
+			
+			// バックアップが上書きされていないことを確認
+			expect(showPoiProperty.isHookActive()).toBe(true); // isHookActiveがtrueのままであることを確認する
+			
+			// リストアして、元の関数が呼び出されることを確認する
+			showPoiProperty.restoreShowPoiProperty();
+			// POIクリックをシミュレート
+			showPoiProperty.showPoiPropertyWrapper(target);
+			expect(initialFunc).toHaveBeenCalledTimes(1); // リストアされて実行回数が1になることを確認
+			expect(customFunc).toHaveBeenCalledTimes(1); // customFuncが呼び出されることを確認
+
+			// ここでは、isHookActiveがfalseであることを確認する
+			expect(showPoiProperty.isHookActive()).toBe(false);
+		});
+
+		it("should not throw error when restoreShowPoiProperty is called without backup", () => {
+			// バックアップがないことを確認
+			expect(showPoiProperty.isHookActive()).toBe(false);
+			
+			// バックアップがない状態でrestoreShowPoiPropertyを呼び出す
+			expect(() => showPoiProperty.restoreShowPoiProperty()).not.toThrow();
+		});
+
+		it("should correctly report hook active status", () => {
+			// 初期状態ではhookはアクティブではない
+			expect(showPoiProperty.isHookActive()).toBe(false);
+
+			// バックアップ後、hookはアクティブになる
+			showPoiProperty.backupShowPoiProperty();
+			expect(showPoiProperty.isHookActive()).toBe(true);
+
+			// リストア後、hookはアクティブではなくなる
+			showPoiProperty.restoreShowPoiProperty();
+			expect(showPoiProperty.isHookActive()).toBe(false);
+		});
+
+		it("should call custom handler set by setShowPoiProperty", () => {
+			const customHandler = jest.fn();
+			showPoiProperty.setShowPoiProperty(customHandler, "i5");
+			
+			// ここでは、setShowPoiPropertyがエラーなく実行されることを確認する
+			expect(() => showPoiProperty.setShowPoiProperty(customHandler, "i5")).not.toThrow();
+		});
+
+		it("should restore original handler after restoreShowPoiProperty", () => {
+			const originalHandler = jest.fn();
+			showPoiProperty.setShowPoiProperty(originalHandler, null);
+			
+			showPoiProperty.backupShowPoiProperty();
+			
+			const newHandler = jest.fn();
+			showPoiProperty.setShowPoiProperty(newHandler, null);
+			
+			showPoiProperty.restoreShowPoiProperty();
+			
+			// ここでは、isHookActiveがfalseであることを確認する
+			expect(showPoiProperty.isHookActive()).toBe(false);
 		});
 	});
 });

--- a/tests/unittest/resources/mockParamerters.js
+++ b/tests/unittest/resources/mockParamerters.js
@@ -18,6 +18,7 @@ const mock_svgmapObj = {
 		i5: {
 			Path: { location: { href: "layer.svg" } },
 			CRS: "",
+			rootLayer: "root"
 		},
 	}),
 	setRootViewBox: mock_setRootViewBox,


### PR DESCRIPTION
## 概要
POI（Point of Interest）クリック時のコールバック関数および表示プロパティを一時的にバックアップし、
必要に応じて元の状態に戻す機能を追加しました。
これにより、一時的なUI変更や元の設定に復元することが可能になります。

---

## 主な変更点

### showPoiProperty クラスへメソッド追加
* `backupShowPoiProperty()`: アクティブなレイヤーのPOIプロパティのバックアップ処理を呼び出します。
* `restoreShowPoiProperty()`: アクティブなレイヤーのPOIプロパティを復元します。

---

## レビュー時のチェックポイント
- [ ] バックアップが存在しない状態で `restoreShowPoiProperty` を呼んでもエラーにならないか。
- [ ] `backupShowPoiProperty` を連続で呼んだ際、1回目のバックアップが正しく保護されているか。
 
---